### PR TITLE
Change from namespace/version dependency to github dependency

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -6,8 +6,7 @@ project:
         api_version: '42.0'
     dependencies:
         - github: 'https://github.com/SalesforceFoundation/Cumulus'
-        - namespace: outfunds 
-          version: 1.13 
+        - github: 'https://github.com/SalesforceFoundation/OutboundFunds'
 
 
 


### PR DESCRIPTION
# Changes

* Changed dependencies in CumulusCI to use github repository for OutboundFunds