### PR TITLE
remove currency-code attribute

### DIFF
--- a/force-app/main/default/lwc/manageExpenditures/manageExpenditures.html
+++ b/force-app/main/default/lwc/manageExpenditures/manageExpenditures.html
@@ -56,7 +56,6 @@
                     <lightning-formatted-number
                       value={remainingAmount}
                       format-style="currency"
-                      currency-code="USD"
                       minimum-fraction-digits="2"
                       maximum-fraction-digits="2"
                     ></lightning-formatted-number>


### PR DESCRIPTION
This PR removes the `currency-code` attribute from the `lightning-formatted-number` field that hosts the running remaining amount for the Disbursement in the `manageExpenditures` lwc.

It appears `lightning-formatted-number` is able to handle varying & multiple currencies quite well when not over-engineered!

# Critical Changes

# Changes

# Issues Closed
- The Total Amount Remaining field in Manage Expenditures always displays a USD currency label, even if the org’s default currency is set to another currency.

#18 
