### PR TITLE
remove currency flag

### DIFF
--- a/force-app/main/default/lwc/manageExpenditures/manageExpenditures.html
+++ b/force-app/main/default/lwc/manageExpenditures/manageExpenditures.html
@@ -56,7 +56,6 @@
                     <lightning-formatted-number
                       value={remainingAmount}
                       format-style="currency"
-                      currency-code="USD"
                       minimum-fraction-digits="2"
                       maximum-fraction-digits="2"
                     ></lightning-formatted-number>


### PR DESCRIPTION

# Critical Changes

# Changes
From original PR #20 
This PR removes the currency-code attribute from the lightning-formatted-number field that hosts the running remaining amount for the Disbursement in the manageExpenditures lwc.

It appears lightning-formatted-number is able to handle varying & multiple currencies quite well when not over-engineered!

# Issues Closed
Fixes #18 

